### PR TITLE
release 0.0.2

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - {{ pin_compatible('fitgrid', lower_bound='0.4.5', upper_bound='0.4.5') }}
     - r-base
     - zeromq !=4.2.5  # buggy version in this env
+    - rpy2 <3.0  # else fitgrid fails on py2ri
     - tornado
     - jupyter
     - rstudio


### PR DESCRIPTION
pinned rpy2 < 3.0 to pass fitgrid which works on 2.9.4