### PR TITLE
release 0.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_install:
     - conda info -a
 install:
     - conda install -q conda-build conda-verify
-#    - bash ./ci/pypi2conda.sh  # wrap pypi packages for conda build see meta.yaml 
     - conda build conda -c kutaslab -c defaults -c conda-forge
     - conda create --name mkconda_env mkconda -c local -c kutaslab -c defaults -c conda-forge
     - conda activate mkconda_env 
@@ -30,14 +29,4 @@ deploy:
       skip_cleanup: true
       script: bash ./ci/conda_upload.sh
       on:
-          all_branches: true
-
-    # - provider: pages
-    #   skip_cleanup: true
-    #   github_token: $GITHUB_TOKEN
-    #   keep-history: true
-    #   on:
-    #       branch: master
-    #   target_branch: gh-pages  # that's the default anyway, just to be explicit
-    #   local_dir: docs/_build/html
-
+        all_branches: true

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,7 +21,7 @@
 
 package:
   name: mkconda
-  version: "0.0.3"
+  version: "0.0.4.dev0"
 
 requirements:
   # hard pins for reproducible analyses
@@ -33,7 +33,7 @@ requirements:
     - rpy2 <3.0  # else fitgrid fails on py2ri
     - tornado
     - jupyter
-    - rstudio
+    # - rstudio
     - r-irkernel
     - bottleneck 
     - libiconv  # rpy2 needs it, not included, reasons unknown

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,8 +26,8 @@ package:
 requirements:
   # hard pins for reproducible analyses
   run:
-    - mkpy ==0.1.6  # {{ pin_compatible('mkpy', lower_bound='0.1.6', upper_bound='0.1.6' )}}
-    - fitgrid ==0.4.6  # {{ pin_compatible('fitgrid', lower_bound='0.4.6', upper_bound='0.4.6') }}
+    - mkpy ==0.1.6
+    - fitgrid ==0.4.6
     - r-base
     - zeromq !=4.2.5  # buggy version in this env
     - rpy2 <3.0  # else fitgrid fails on py2ri
@@ -35,11 +35,11 @@ requirements:
     - jupyter
     # - rstudio  # chokes conda env resolver, TravisCI times out
     - r-irkernel
-    - bottleneck 
+    - bottleneck
     - libiconv  # rpy2 needs it, not included, reasons unknown
     - numpy  # these should already be satisfied
     - scipy
-    - pandas 
+    - pandas
     - matplotlib >=3.0
     - statsmodels
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - rpy2 <3.0  # else fitgrid fails on py2ri
     - tornado
     - jupyter
-    # - rstudio
+    # - rstudio  # chokes conda env resolver, TravisCI times out
     - r-irkernel
     - bottleneck 
     - libiconv  # rpy2 needs it, not included, reasons unknown

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - tornado
     - jupyter
     # - rstudio  # chokes conda env resolver, TravisCI times out
+    - r-tidyverse
     - r-irkernel
     - bottleneck
     - libiconv  # rpy2 needs it, not included, reasons unknown

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,13 +21,13 @@
 
 package:
   name: mkconda
-  version: "0.0.4.dev0"
+  version: "0.0.4"
 
 requirements:
   # hard pins for reproducible analyses
   run:
-    - {{ pin_compatible('mkpy', lower_bound='0.1.6', upper_bound='0.1.6' )}}
-    - {{ pin_compatible('fitgrid', lower_bound='0.4.5', upper_bound='0.4.5') }}
+    - mkpy ==0.1.6  # {{ pin_compatible('mkpy', lower_bound='0.1.6', upper_bound='0.1.6' )}}
+    - fitgrid ==0.4.6  # {{ pin_compatible('fitgrid', lower_bound='0.4.6', upper_bound='0.4.6') }}
     - r-base
     - zeromq !=4.2.5  # buggy version in this env
     - rpy2 <3.0  # else fitgrid fails on py2ri


### PR DESCRIPTION
Dropped rstudio from the package: conda env resolution during builds too slow, TravisCI timed out.