### PR TITLE
version 0.0.4

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,13 +21,14 @@
 
 package:
   name: mkconda
-  version: "0.0.4"
+  version: "0.0.4.dev1"
 
 requirements:
   # hard pins for reproducible analyses
   run:
     - mkpy ==0.1.6
     - fitgrid ==0.4.6
+    - blas =1.0  # for fitgrid thread setting, -rstudio +tidyverse promotes
     - r-base
     - zeromq !=4.2.5  # buggy version in this env
     - rpy2 <3.0  # else fitgrid fails on py2ri


### PR DESCRIPTION
Changing packages -rstudio, +tidyverse promoted blas from 1.0-mkl to 2>openblas

This breaks fitgrid thread tools, pinned blas=1.0