### PR TITLE
CI pin for rpy2

### DIFF
--- a/.github/workflows/mkconda-cid.yml
+++ b/.github/workflows/mkconda-cid.yml
@@ -46,8 +46,8 @@ on:
     types: [published]
 
   schedule:
-    # min hour day of month, day of week = when, / = step by, * = all
-    # weekly on Sunday
+    # min hour day month year. digit = when, / = step by, * = all
+    # Sunday midnight
     - cron: '0 0 * * 0'
 
 env:

--- a/.github/workflows/mkconda-cid.yml
+++ b/.github/workflows/mkconda-cid.yml
@@ -46,8 +46,8 @@ on:
     types: [published]
 
   schedule:
-    # min hour day month year. digit = when, / = step by, * = all
-    # Sunday midnight
+    # min hour day of month, day of week = when, / = step by, * = all
+    # weekly on Sunday
     - cron: '0 0 * * 0'
 
 env:

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ CPUS and NVIDIA GPUS, among them:
 * jupyterlab - Jupyter notebook desktop + Python and R kernels
 * spyder - Python IDE
 * tidyverse - data wrangling utilities in R
-# DROPPED PENDING FIX OF cudatoolkit-dev 11.4 MAMBA INSTALL
-* ~~cudatoolkit-dev~~
-* ~~rapids - NVIDIA Python GPU accelerators~~
 * pytorch - tensor library for deep learning
 * numba - CPU and GPU Python acclerators
 * Intel Math Kernel (MKL) library - math libraries optimized for Intel CPUs
+
+**DROPPED PENDING FIX OF cudatoolkit-dev 11.4 MAMBA INSTALL**
+
+* ~~cudatoolkit-dev~~
+* ~~rapids - NVIDIA Python GPU accelerators~~
 
 
 ## Installation
@@ -45,7 +47,7 @@ environment like so:
 
 ```
 (mkconda_072221) $ conda list
-(mkconda_072221) $ mamba install -c conda-forge -c defaults package_a package_b ...
+(mkconda_072221) $ mamba install --strict-channel-priority -c conda-forge -c defaults package_a package_b ...
 
 ```
 
@@ -57,7 +59,7 @@ code to reside, and install the development branch from source into
 the working environment in editable ("development") mode like so:
 
 ```
-(base) $ mamba create --name mkconda_072221 -c conda-forge -c defaults -c ejolly -c kutaslab
+(base) $ mamba create --name mkconda_072221 --strict-channel-priority -c conda-forge -c defaults -c ejolly -c kutaslab
 (base) $ conda activate mkconda_072221
 (mkconda_072221) $ cd path/to/local_source_dirs
 (mkconda_072221) $ git clone https://github.com/the_package --single-branch -b the_branch

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - spyder
     - odfpy
     - ipywidgets
+    - rpy2 <3.5  # 3.5.1 breaks pymer4 05/30/22
     # pending mamba/boa install fix
     # - rapids
     # - cudatoolkit-dev


### PR DESCRIPTION
Pinned rpy2 < 3.5 in conda/meta.yaml.  As of this writing the versioned Python 3.X fitgrid CI jobs are passing in the fitgrid repo but mkconda is a noarch build and rpy2 3.5.X leaks in which breaks pymer4.
